### PR TITLE
Fix Icon of AppSwitcher

### DIFF
--- a/lib/components/app-switcher/AppSwitcher.vue
+++ b/lib/components/app-switcher/AppSwitcher.vue
@@ -29,9 +29,9 @@
             :disabled="app.disabled"
             @click="setCurrentApp(app)"
           >
-            <v-list-item-icon class="mr-2">
+            <v-list-item-icon class="mr-2 align-center">
               <div :style="`width: 20px; height: 20px; background-color: ${app.color}`">
-                <img :src="base64ImageURI(app.svg_icon)" />
+                <img width="100%" :src="base64ImageURI(app.svg_icon)" />
               </div>
             </v-list-item-icon>
             <v-list-item-title>{{ app.title }}</v-list-item-title>


### PR DESCRIPTION
The icon were sometime too big we tried to fix it to a given size (i.e. wight 100%) and align it to the center.