### PR TITLE
Checking the branch name

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -6,6 +6,7 @@
     }
   },
   "hooks": {
+    "before:init": "if ! (git branch --show-current | grep  \"^master$\"); then exit 1 ; fi",
     "after:release": "./publish-docs.sh"
   }
 }


### PR DESCRIPTION
Releases should always be made in the master. With the addtion of this hook the release is aborted if the branch  name is not "master" 