### PR TITLE
Show warning if not all items are selected

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [serverside-collection] Introduce a slot to show a warning when only the current page is being selected.
+
 ## [1.3.0] - 2022-05-04
 
 - [serverside-collection] Added a new component ``CustomTable`` to provide a more tabular layout option.

--- a/docs/components/serverside-data/README.md
+++ b/docs/components/serverside-data/README.md
@@ -197,10 +197,11 @@ The component passes all props to its child components, e.g. it passes the `head
 
 ## Slots
 
-| Name            | Description                                                                            |
-|-----------------|----------------------------------------------------------------------------------------|
-| ``item``        | Slot to set the layout used for the listing representation displayed on small screens. |
-| ``title``       | Slot used to render a title at the top of each table row.                              |
+| Name                   | Description                                                                                          |
+|------------------------|------------------------------------------------------------------------------------------------------|
+| ``item``               | Slot to set the layout used for the listing representation displayed on small screens.               |
+| ``title``              | Slot used to render a title at the top of each table row.                                            |
+| ``select-all-warning`` | Slot used to render a warning, informing users, that not all items on every page have been selected. |
 
 Additionally, the component passes all slots to its child components, e.g. the slot ``item.<name>`` can be used to customize a specific column.
 

--- a/lib/components/serverside-data/CustomTable.vue
+++ b/lib/components/serverside-data/CustomTable.vue
@@ -12,6 +12,14 @@
       <v-simple-checkbox :indeterminate="props.indeterminate" :ripple="false" :value="props.value" v-on="on" />
     </template>
 
+    <template #body.prepend="{ items, pagination: { itemsLength } }">
+      <tr v-if="$attrs.onlyCurrentPageSelected && $scopedSlots['select-all-warning']">
+        <td class="body-2 px-5 py-3 warning" colspan="100">
+          <slot v-bind="{ count: itemsLength, items }" name="select-all-warning" />
+        </td>
+      </tr>
+    </template>
+
     <template #item="{ isSelected, item, select }">
       <tr :class="{ highlighted: $route.hash === `#${item.id}`, selected: isSelected }">
         <td v-if="showSelect" class="select-cell">

--- a/lib/components/serverside-data/ServersideTable.vue
+++ b/lib/components/serverside-data/ServersideTable.vue
@@ -3,10 +3,13 @@
     <template #items="{ count, items }">
       <component
         :is="tableComponent"
-        v-bind="{ ...tableAttrs, items, icon, loading }"
+        v-bind="{ ...tableAttrs, items, icon, loading, onlyCurrentPageSelected }"
         :server-items-length="count"
         @update:options="$emit('update:options', $event)"
         @input="$emit('input', $event)"
+        @toggle-select-all="toggleSelectAll({ ...$event, count })"
+        @current-items="toggleSelectAll({ value: false })"
+        @item-selected="toggleSelectAll({ value: false })"
       >
         <template v-for="(index, name) in $scopedSlots" v-slot:[name]="data">
           <slot :name="name" v-bind="data"></slot>
@@ -49,6 +52,7 @@ export default {
   data() {
     return {
       loading: true,
+      onlyCurrentPageSelected: false,
     }
   },
   computed: {
@@ -60,6 +64,13 @@ export default {
     },
   },
   methods: {
+    toggleSelectAll({ count, items = [], value }) {
+      if (value && items.length < count) {
+        this.onlyCurrentPageSelected = true
+        return
+      }
+      this.onlyCurrentPageSelected = false
+    },
     update() {
       this.$refs.iterator.update()
     },

--- a/lib/components/serverside-data/Table.vue
+++ b/lib/components/serverside-data/Table.vue
@@ -13,7 +13,7 @@
       <v-simple-checkbox :indeterminate="props.indeterminate" :ripple="false" :value="props.value" v-on="on" />
     </template>
 
-    <template #body="{ isSelected, items, select }">
+    <template #body="{ isSelected, items, select, pagination: { itemsLength } }">
       <tbody v-if="$attrs.loading">
         <tr>
           <td colspan="100">
@@ -29,6 +29,11 @@
         </tr>
       </tbody>
       <template v-else>
+        <tr v-if="$attrs.onlyCurrentPageSelected && $scopedSlots['select-all-warning']">
+          <td class="body-2 px-5 py-3 warning" colspan="100">
+            <slot v-bind="{ count: itemsLength, items }" name="select-all-warning" />
+          </td>
+        </tr>
         <tbody
           v-for="item in items"
           :id="item.id"

--- a/pages/serverside-collection.vue
+++ b/pages/serverside-collection.vue
@@ -22,7 +22,11 @@
       :table-style="tableStyle"
       count-property="total_jokes"
       page-size-param="limit"
+      show-select
     >
+      <template #select-all-warning="{ count, items }">
+        {{ `${items.length} jokes on this page are selected (total jokes: ${count}).` }}
+      </template>
       <template #title="{ item: { joke } }">
         {{ joke }}
       </template>


### PR DESCRIPTION
When clicking the "select all" checkbox a warning is displayed, informing users that not all items on every page are selected. The slot is only visible if the selected items count is lower than the total amount of items and if the slot `select-all-warning` is being used.

<img width="905" alt="image" src="https://user-images.githubusercontent.com/5048550/167407217-36481602-5890-4062-97f9-d3545668fe17.png">
