### PR TITLE
Improvements to `select-all-warning` slot

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - [serverside-collection] Make `select-all-warning` slot more customizable by using a `v-alert` component and adding a CSS class.
+- [serverside-collection] Better handle when the `select-all-warning` slot is visible and emit more `v-data-table` events to allow more control over item selection from parent components.
+
 ## [1.4.0] - 2022-05-10
 
 - [serverside-collection] Introduce a slot to show a warning when only the current page is being selected.

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [serverside-collection] Make `select-all-warning` slot more customizable by using a `v-alert` component and adding a CSS class.
 ## [1.4.0] - 2022-05-10
 
 - [serverside-collection] Introduce a slot to show a warning when only the current page is being selected.

--- a/docs/components/serverside-data/README.md
+++ b/docs/components/serverside-data/README.md
@@ -194,6 +194,8 @@ The component passes all props to its child components, e.g. it passes the `head
 | update:loading | Emits the loading state of the component.                                                                                           |
 | update:options | Emits the options state for the underlying v-data-table component. You can use this to change the sorting when a header is clicked. |
 | input          | Emits an array of selected items when the selection is changed.                                                                     |
+| item-selected  | Event emitted when an item is selected or deselected by emitting the item and its selection state.                                  |
+| current-items  | Emits the items provided via the items prop, every time the internal computedItems is changed.                                      |
 
 ## Slots
 

--- a/lib/components/serverside-data/CustomTable.vue
+++ b/lib/components/serverside-data/CustomTable.vue
@@ -14,8 +14,10 @@
 
     <template #body.prepend="{ items, pagination: { itemsLength } }">
       <tr v-if="$attrs.onlyCurrentPageSelected && $scopedSlots['select-all-warning']">
-        <td class="body-2 px-5 py-3 warning" colspan="100">
-          <slot v-bind="{ count: itemsLength, items }" name="select-all-warning" />
+        <td class="pa-0" colspan="100">
+          <v-alert class="body-2 ma-0 select-all-warning" dense text tile>
+            <slot v-bind="{ count: itemsLength, items }" name="select-all-warning" />
+          </v-alert>
         </td>
       </tr>
     </template>

--- a/lib/components/serverside-data/Table.vue
+++ b/lib/components/serverside-data/Table.vue
@@ -30,8 +30,10 @@
       </tbody>
       <template v-else>
         <tr v-if="$attrs.onlyCurrentPageSelected && $scopedSlots['select-all-warning']">
-          <td class="body-2 px-5 py-3 warning" colspan="100">
-            <slot v-bind="{ count: itemsLength, items }" name="select-all-warning" />
+          <td class="pa-0" colspan="100">
+            <v-alert class="body-2 ma-0 select-all-warning" dense text tile>
+              <slot v-bind="{ count: itemsLength, items }" name="select-all-warning" />
+            </v-alert>
           </td>
         </tr>
         <tbody


### PR DESCRIPTION
This PR makes improvements to the `select-all-warning` slot.

1. Make the layout better customizable: By adding a CSS class to the slot it is possible to more easily make changes to the layout. Also, use a `v-alert` component for a less intrusive look and feel.

Before:

<img width="911" alt="image" src="https://user-images.githubusercontent.com/5048550/167783315-1f0618fb-2a3f-4cd5-a48e-1b62bff34a15.png">

After:

<img width="906" alt="image" src="https://user-images.githubusercontent.com/5048550/167783241-4441aa11-7a0b-4046-a906-fedb7a3ac62e.png">


3. Better control the slot's visibility: The slot should be hidden again if users deselect any items or if the items being displayed change (i.e. filters are applied or user changes page). Also, deselect all items on any page if the user toggles the "select all" checkbox to `false`. These behaviours are copied over from Google mail.

4. Emit `v-data-table`'s `item-selected` and `current-items`, so parent components can better control item selection from outside the component.