### PR TITLE
Support custom table ordering

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [serverside-collection] Handle sorting for custom tables style.
+
 ## [1.4.2] - 2022-05-17
 
 - [app-switcher] Fixing the size of the currentApp-icon

--- a/docs/components/serverside-data/README.md
+++ b/docs/components/serverside-data/README.md
@@ -113,6 +113,7 @@ export default {
 
 A filter can be defined and modified outside component. If it changes, the component fetches the data again. This works well with the component ``<ftw-text-filter-field>`` for example.
 Similarly, the ordering parameter can be part of the filter. One may use the component ``<ftw-ordering-menu>`` for this.
+The ordering parameter is automatically updated for sortable columns for the `CustomTable` style. The ordering is thereby a list of columns being sorted. The sorting direction is identified by a `-` for descending and no prefix for ascending. This schema is heavily inspired by https://www.django-rest-framework.org/api-guide/filtering/#orderingfilter.
 
 ```vue
 <template>

--- a/pages/serverside-collection.vue
+++ b/pages/serverside-collection.vue
@@ -70,7 +70,7 @@ import { fromQueryString } from '~/lib/util/query'
 export default {
   data() {
     return {
-      filter: fromQueryString(this.$route.query, ['term'], { term: '' }),
+      filter: fromQueryString(this.$route.query, ['term', 'ordering'], { term: '', ordering: [] }),
       tableStyle: 'table',
     }
   },


### PR DESCRIPTION
The serverside iterator now detects when a column header is clicked
for ordering and update the filter accordingly.