### PR TITLE
Fix empty ordering in custom table

### DIFF
--- a/lib/components/serverside-data/ServersideTable.vue
+++ b/lib/components/serverside-data/ServersideTable.vue
@@ -82,12 +82,17 @@ export default {
       this.$emit('current-items', props)
     },
     handleUpdateOptions(options) {
-      const ordering = zip(options.sortBy, options.sortDesc).map(([sortBy, sortDesc]) => {
-        const sortDirection = sortDesc ? '-' : ''
-        return sortDirection + sortBy
-      })
-      this.filter.ordering = ordering
-      this.$emit('update:options', options)
+      if (!options.sortBy.length) {
+        this.filter.ordering = []
+        this.$emit('update:options', options)
+      } else {
+        const ordering = zip(options.sortBy, options.sortDesc).map(([sortBy, sortDesc]) => {
+          const sortDirection = sortDesc ? '-' : ''
+          return sortDirection + sortBy
+        })
+        this.filter.ordering = ordering
+        this.$emit('update:options', options)
+      }
     },
     toggleSelectAll({ count, items, value }) {
       if (value && items.length < count) {


### PR DESCRIPTION
For some reason when the v-datatable is not ordered, vuetify prefills the sortDesc property with `[false]`. As a result the ordering filter is `undefined`, since the zip tries to zip the empty list from `sortBy` with `[false]`. So, first check if `sortBy` is empty to clear the ordering in that case.