### PR TITLE
Let the serverside table handle the sort options

### DIFF
--- a/lib/components/serverside-data/CustomTable.vue
+++ b/lib/components/serverside-data/CustomTable.vue
@@ -2,7 +2,6 @@
   <v-data-table
     v-bind="{ ...$attrs, headers: tableHeaders }"
     :class="{ 'show-icon': showIcon, 'show-select': showSelect }"
-    :options="options"
     class="gever-custom-table"
     dense
     hide-default-footer
@@ -53,12 +52,6 @@ import get from 'lodash/get'
 export default {
   name: 'CustomTable',
   inheritAttrs: false,
-  props: {
-    options: {
-      type: Object,
-      default: () => ({}),
-    },
-  },
   computed: {
     headers() {
       return get(this.$attrs, 'headers', [])

--- a/lib/components/serverside-data/Table.vue
+++ b/lib/components/serverside-data/Table.vue
@@ -5,7 +5,6 @@
     dense
     disable-pagination
     hide-default-footer
-    :options="options"
     v-bind="{ ...$attrs, headers: tableHeaders }"
     v-on="$listeners"
   >
@@ -84,12 +83,6 @@ import get from 'lodash/get'
 export default {
   name: 'Table',
   inheritAttrs: false,
-  props: {
-    options: {
-      type: Object,
-      default: () => ({}),
-    },
-  },
   computed: {
     tableHeaders() {
       const headers = this.headers.map((h) => ({ ...h, sortable: h.sortable ? h.sortable : false }))


### PR DESCRIPTION
It is very briddle to allow the component's user fiddling around with the options settings because it may become invalid. So now we are under the options propery control. This also allows us to define a converter for the ordering filer. So, whenever the sortDesc or sortBy changes in the options, the component will translate that to a DRF compatible format. It is also not necessary to check for empty sortBy's, since the zip automatically handles empty lists and thus not leaving the options settings invalid.