### PR TITLE
Render app-switcher apps with url values as anchor elements

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [app-switcher] Apps with url values are rendered as anchor elements.
+
 ## [1.5.3] - 2022-06-02
 
 - [app-layout] Allow hiding the app information section of the navigation.

--- a/lib/components/app-switcher/AppSwitcher.vue
+++ b/lib/components/app-switcher/AppSwitcher.vue
@@ -31,6 +31,7 @@
             v-for="(app, index) in apps"
             :key="`app-${index}`"
             :disabled="app.disabled"
+            :href="app.url"
             @click="setCurrentApp(app)"
           >
             <v-list-item-icon class="mr-2 align-center">


### PR DESCRIPTION
Adding the propery 'useAnchorTags' to the AppSwitcher. If enabled, apps with url value will be using the 'a' tag, so users can right-click it to open the link in a new tab or copy it to the clipboard.