### PR TITLE
set color of active application to blue

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [app-switcher] Set color of active application to blue.
+
 ## [1.6.0] - 2022-08-08
 
 - [app-switcher] Apps with url values are rendered as anchor elements.

--- a/lib/components/app-switcher/AppSwitcher.vue
+++ b/lib/components/app-switcher/AppSwitcher.vue
@@ -40,7 +40,7 @@
               </div>
             </v-list-item-icon>
             <v-list-item-title>{{ app.title }}</v-list-item-title>
-            <v-list-item-action v-if="isCurrentApp(app)" class="caption primary--text text-no-wrap grow ml-8">
+            <v-list-item-action v-if="isCurrentApp(app)" class="caption active--text text-no-wrap grow ml-8">
               {{ $t('appSwitcher.currentApp') }}
             </v-list-item-action>
             <v-list-item-action v-else-if="app.disabled" class="caption primary--text text-no-wrap grow ml-8">

--- a/themes/light.js
+++ b/themes/light.js
@@ -1,4 +1,5 @@
 module.exports = {
+  active: '#00b0ff',
   accent: '#00b0ff', // same as primary
   bodydark: '#37474f',
   bodylight: '#5f7481',


### PR DESCRIPTION
Set the color of the text "Active Application" to blue because the primary color is not the same in every app. 

<img width="259" alt="Screenshot 2022-10-03 at 12 14 18" src="https://user-images.githubusercontent.com/54574289/193553707-1f1ebf33-4ba8-4e02-ae76-a86c1bc15feb.png">
