### PR TITLE
Return placeholder label correctly

### DIFF
--- a/lib/components/fields/TextFilterField.vue
+++ b/lib/components/fields/TextFilterField.vue
@@ -24,7 +24,9 @@ export default {
     },
     placeholder: {
       type: String,
-      default: () => this.$t('textFilterField.placeholder'),
+      default() {
+        return this.$t('textFilterField.placeholder')
+      },
     },
   },
   computed: {


### PR DESCRIPTION
An arrow function can't access for some reason the correct `this` when defining a default value for a prop. So change it to a normal function. 👔