### PR TITLE
Fix publish-docs script

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [publish-docs] `git init` creates a `main` branch but on github the main branch is still called `master`. Use `--initial-branch=master` so both branch name match and docs can still be published.
+
 ## [1.6.5] - 2022-12-19
 
 - [serverside-iterator] If `fetch` is called multiple times, only return last result in order to prevent older requests that might run longer to override the last request's results.

--- a/publish-docs.sh
+++ b/publish-docs.sh
@@ -6,7 +6,7 @@ set -e
 yarn docs:build
 cd docs/.vuepress/dist
 
-git init
+git init --initial-branch=master
 git add -A
 git commit -m 'deploy'
 git push -f git@github.com:4teamwork/ui.git master:gh-pages


### PR DESCRIPTION
Add `--initial-branch=master` to script so local and remote main branch names still match.