### PR TITLE
ServersideIterator.vue: Add prop 'routeReplace'

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [serverside-iterator] If `routeReplace` is `true`, changes to the current URL path by the filter state will not create a new history entry.
+
 ## [1.9.0] - 2023-07-25
 
 - [custom-table] Headers can now be rearranged by dragging individual headers arround.

--- a/lib/components/serverside-data/ServersideIterator.vue
+++ b/lib/components/serverside-data/ServersideIterator.vue
@@ -78,6 +78,10 @@ export default {
       type: Boolean,
       default: () => false,
     },
+    routeReplace: {
+      type: Boolean,
+      default: () => false,
+    },
     itemsPerPageOptions: {
       type: Array,
       default: () => defaultItemsPerPageOptions,
@@ -178,10 +182,8 @@ export default {
   created() {
     this.debouncedUpdate = debounceAsync(async function debouncedUpdate() {
       if (!this.disableRouteSync) {
-        this.$router.push({
-          name: this.$route.name,
-          query: this.computedFilter,
-        })
+        const to = { name: this.$route.name, query: this.computedFilter }
+        this.routeReplace ? this.$router.replace(to) : this.$router.push(to)
       }
       this.$emit('update:loading', true)
       try {


### PR DESCRIPTION
If this is true, $router.replace is used instead of $router.push on filter state changes.
This prevents new history entries.