### PR TITLE
ServersideIterator.vue: Fix 'NavigationDuplicated'

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [serverside-iterator] Fix an error that is thrown by VueRouter when replacing the route with no changes to the path.
+
 ## [1.9.1] - 2023-09-22
 
 - [serverside-iterator] If `routeReplace` is `true`, changes to the current URL path by the filter state will not create a new history entry.

--- a/lib/components/serverside-data/ServersideIterator.vue
+++ b/lib/components/serverside-data/ServersideIterator.vue
@@ -183,7 +183,7 @@ export default {
     this.debouncedUpdate = debounceAsync(async function debouncedUpdate() {
       if (!this.disableRouteSync) {
         const to = { name: this.$route.name, query: this.computedFilter }
-        this.routeReplace ? this.$router.replace(to) : this.$router.push(to)
+        this.routeReplace ? this.$router.replace(to).catch((e) => {}) : this.$router.push(to)
       }
       this.$emit('update:loading', true)
       try {


### PR DESCRIPTION
$router.replace throws the error 'NavigationDuplicated' when query params change but not the url path. The current URL is still correctly updated though.
See https://github.com/vuejs/vue-router/issues/2872#issuecomment-522341874