### PR TITLE
Provide a slot to override the company logo

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [app-layout] Provide a slot to override the company logo.
+
 ## [1.9.2] - 2023-10-17
 
 - [serverside-iterator] Fix an error that is thrown by VueRouter when replacing the route with no changes to the path.

--- a/docs/components/app-layout/README.md
+++ b/docs/components/app-layout/README.md
@@ -149,6 +149,7 @@ export default {
 | toolbar-root    | Slot to replace the whole toolbar                                             |
 | toolbar-actions | Slot to fill in actions for the toolbar next to the user menu                 |
 | app-icon        | Slot to define an app icon in top left corner                                 |
+| company-logo    | Slot to define the company logo in the navigation's lower part                |
 | usermenu        | Slot to fill in the usermenu                                                  |
 | avatar          | Slot to replace the whole avatar                                              |
 | avatar-image    | Slot to set image of the user avatar                                          |

--- a/lib/components/app-layout/AppLayout.vue
+++ b/lib/components/app-layout/AppLayout.vue
@@ -20,6 +20,9 @@
         <template v-slot:app-icon>
           <slot name="app-icon" />
         </template>
+        <template v-slot:company-logo>
+          <slot name="company-logo" />
+        </template>
       </Navigation>
     </slot>
     <slot name="toolbar-root">

--- a/lib/components/app-layout/Navigation.vue
+++ b/lib/components/app-layout/Navigation.vue
@@ -28,7 +28,9 @@
           <span class="caption bodylight--text text-no-wrap">{{ `${appName} ${version}` }}</span>
           <div class="d-flex pb-4 pt-2 align-center">
             <span class="caption bodylight--text text-no-wrap pr-1">Created by</span>
-            <CompanyLogo />
+            <slot name="company-logo">
+              <CompanyLogo />
+            </slot>
           </div>
         </div>
       </v-fade-transition>


### PR DESCRIPTION
ftw-ui is being used by the histify ag as well. The company logo is different from the default. The new slot provides a simple way to override the logo.